### PR TITLE
For Anonymous Users Delete the JWT Cookie

### DIFF
--- a/src/cromlech/sessions/jwt/__init__.py
+++ b/src/cromlech/sessions/jwt/__init__.py
@@ -69,18 +69,14 @@ class JWTCookieSession(JWTService):
                 #and the expires time to be now.
                 
                 if  session_data:
-                   token = self.generate(session_data)
-                   expires = datetime.now() + timedelta(minutes=self.lifetime)
-                else:
-                    token =self.generate({})
-                    expires = datetime(2000,1,1)
-
-                cookie = Cookie(
-                    name=self.cookie_name, value=token, path=path,
-                    domain=domain, expires=expires)
-                cookie_value = str(cookie)
-                self.check_cookie_size(cookie_value)
-                headers.append(('Set-Cookie', cookie_value))
+                    token = self.generate(session_data)
+                    expires = datetime.now() + timedelta(minutes=self.lifetime)
+                    cookie = Cookie(
+                        name=self.cookie_name, value=token, path=path,
+                        domain=domain, expires=expires)
+                    cookie_value = str(cookie)
+                    self.check_cookie_size(cookie_value)
+                    headers.append(('Set-Cookie', cookie_value))
                 return start_response(status, headers, exc_info)
             
             session = self.extract_session(environ)

--- a/src/cromlech/sessions/jwt/__init__.py
+++ b/src/cromlech/sessions/jwt/__init__.py
@@ -72,8 +72,8 @@ class JWTCookieSession(JWTService):
                    token = self.generate(session_data)
                    expires = datetime.now() + timedelta(minutes=self.lifetime)
                 else:
-                   token =''
-                   expires = datetime.now()
+                    token =self.generate({})
+                    expires = datetime(2000,1,1)
 
                 cookie = Cookie(
                     name=self.cookie_name, value=token, path=path,

--- a/src/cromlech/sessions/jwt/__init__.py
+++ b/src/cromlech/sessions/jwt/__init__.py
@@ -58,6 +58,11 @@ class JWTCookieSession(JWTService):
 
             def session_start_response(status, headers, exc_info=None):
                 session_data = environ[self.environ_key]
+
+                # DO NOT SET A COOKIN ON ANONYMOUS USERS
+                if not session_data :
+                   return start_response(status, headers, exc_info)
+
                 token = self.generate(session_data)
                 path = environ['SCRIPT_NAME'] or '/'
                 domain = environ['HTTP_HOST'].split(':', 1)[0]

--- a/src/cromlech/sessions/jwt/__init__.py
+++ b/src/cromlech/sessions/jwt/__init__.py
@@ -5,6 +5,8 @@ from functools import wraps
 from biscuits import parse, Cookie
 from datetime import datetime, timedelta
 from cromlech.jwt.components import JWTService, JWTHandler, ExpiredToken
+from cromlech.browser import getSession,setSession
+from cromlech.jwt import InvalidToken
 
 load_key = JWTHandler.load_key
 
@@ -80,8 +82,12 @@ class JWTCookieSession(JWTService):
                 self.check_cookie_size(cookie_value)
                 headers.append(('Set-Cookie', cookie_value))
                 return start_response(status, headers, exc_info)
-
-            session = self.extract_session(environ)
+            import pdb; pdb.set_trace()
+            try:
+               session = self.extract_session(environ)
+            except InvalidToken:
+               setSession()
+               session = getSession()                       
             environ[self.environ_key] = session
             return app(environ, session_start_response)
         return jwt_session_wrapper

--- a/src/cromlech/sessions/jwt/__init__.py
+++ b/src/cromlech/sessions/jwt/__init__.py
@@ -63,7 +63,7 @@ class JWTCookieSession(JWTService):
 
                 #if there is no registered user
                 #then delete the cookie on the client.
-                #by setting the contents to be teh empty string
+                #by setting the contents to be the empty string
                 #and the expires time to be now.
                 
                 if  session_data:

--- a/src/cromlech/sessions/jwt/__init__.py
+++ b/src/cromlech/sessions/jwt/__init__.py
@@ -58,15 +58,21 @@ class JWTCookieSession(JWTService):
 
             def session_start_response(status, headers, exc_info=None):
                 session_data = environ[self.environ_key]
-
-                # DO NOT SET A COOKIN ON ANONYMOUS USERS
-                if not session_data :
-                   return start_response(status, headers, exc_info)
-
-                token = self.generate(session_data)
                 path = environ['SCRIPT_NAME'] or '/'
                 domain = environ['HTTP_HOST'].split(':', 1)[0]
-                expires = datetime.now() + timedelta(minutes=self.lifetime)
+
+                #if there is no registered user
+                #then delete the cookie on the client.
+                #by setting the contents to be teh empty string
+                #and the expires time to be now.
+                
+                if  session_data:
+                   token = self.generate(session_data)
+                   expires = datetime.now() + timedelta(minutes=self.lifetime)
+                else:
+                   token =''
+                   expires = datetime.now()
+
                 cookie = Cookie(
                     name=self.cookie_name, value=token, path=path,
                     domain=domain, expires=expires)

--- a/src/cromlech/sessions/jwt/__init__.py
+++ b/src/cromlech/sessions/jwt/__init__.py
@@ -82,7 +82,6 @@ class JWTCookieSession(JWTService):
                 self.check_cookie_size(cookie_value)
                 headers.append(('Set-Cookie', cookie_value))
                 return start_response(status, headers, exc_info)
-            import pdb; pdb.set_trace()
             try:
                session = self.extract_session(environ)
             except InvalidToken:

--- a/src/cromlech/sessions/jwt/__init__.py
+++ b/src/cromlech/sessions/jwt/__init__.py
@@ -44,7 +44,7 @@ class JWTCookieSession(JWTService):
                 try:
                     session_data = self.check_token(token)
                     return session_data
-                except ExpiredToken:
+                except (ExpiredToken,InvalidToken) as e:
                     # The token is expired.
                     # We'll return an empty session.
                     pass
@@ -82,11 +82,8 @@ class JWTCookieSession(JWTService):
                 self.check_cookie_size(cookie_value)
                 headers.append(('Set-Cookie', cookie_value))
                 return start_response(status, headers, exc_info)
-            try:
-               session = self.extract_session(environ)
-            except InvalidToken:
-               setSession()
-               session = getSession()                       
+            
+            session = self.extract_session(environ)
             environ[self.environ_key] = session
             return app(environ, session_start_response)
         return jwt_session_wrapper


### PR DESCRIPTION
In order to allow nginx to serve anonymous users, delete the jwt cookie by
setting the expiry time to be now, and the contents to be  the empty string. 